### PR TITLE
<feat> : Repository 설계 완료 / 호연

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,10 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+//    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
+    testImplementation 'com.h2database:h2'
+//    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'`
 }
 
 tasks.named('test') {

--- a/src/main/java/com/chaeshin/boo/domain/Notice.java
+++ b/src/main/java/com/chaeshin/boo/domain/Notice.java
@@ -20,4 +20,7 @@ public class Notice {
 
     @CreatedDate // TZ 확인하기
     private LocalDateTime createdAt;
+
+    // 편의 기능 메서드
+    public void updateNotice(String newBody){this.body = newBody;}
 }

--- a/src/main/java/com/chaeshin/boo/domain/User.java
+++ b/src/main/java/com/chaeshin/boo/domain/User.java
@@ -22,4 +22,10 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Review> reviews = new ArrayList<>();
+
+
+    // 편의 기능 메서드 : 추후 서비스 상 변경을 제공하는 경우를 위해 정의한다
+    public void updateUserNickname(String nickname){
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/chaeshin/boo/domain/restaurant/Restaurant.java
+++ b/src/main/java/com/chaeshin/boo/domain/restaurant/Restaurant.java
@@ -1,8 +1,11 @@
 package com.chaeshin.boo.domain.restaurant;
 
 import com.chaeshin.boo.domain.review.Review;
+import com.chaeshin.boo.repository.restaurant.RestaurantRepository;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.math.BigDecimal;
@@ -11,6 +14,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @Table(indexes = @Index(name = "restaurant_index", columnList = "name"))
 public class Restaurant {
 
@@ -39,4 +43,5 @@ public class Restaurant {
 
     @OneToMany(mappedBy = "restaurant", cascade = CascadeType.ALL)
     private List<Menu> menus = new ArrayList<>();
+
 }

--- a/src/main/java/com/chaeshin/boo/domain/review/Review.java
+++ b/src/main/java/com/chaeshin/boo/domain/review/Review.java
@@ -40,4 +40,22 @@ public class Review {
 
     @CreatedDate
     private LocalDateTime createdAt;
+
+
+    // 편의 기능 메서드 - 수정 API 를 제공하는 필드에 대한 수정 메서드 정의
+
+    /**
+     * 리뷰 제목 수정
+     * @param newTitle
+     */
+    public void updateTitle(String newTitle){this.title = newTitle;}
+
+
+    /**
+     * 리뷰 본문 수정
+     * @param newBody
+     */
+    public void updateBody(String newBody){this.title = newBody;}
+
+
 }

--- a/src/main/java/com/chaeshin/boo/domain/review/ReviewImage.java
+++ b/src/main/java/com/chaeshin/boo/domain/review/ReviewImage.java
@@ -2,6 +2,7 @@ package com.chaeshin.boo.domain.review;
 
 import com.chaeshin.boo.domain.User;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,7 +16,16 @@ public class ReviewImage {
 
     private String imageUrl;
 
+    @NotNull // @NotNull 제약 추가.
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
+
+    // 편의 기능 메서드
+
+    /**
+     * ReviewImage 이미지 변경
+     * @param newImageUrl
+     */
+    public void updateReviewImage(String newImageUrl){this.imageUrl = newImageUrl;}
 }

--- a/src/main/java/com/chaeshin/boo/domain/review/TranslatedReview.java
+++ b/src/main/java/com/chaeshin/boo/domain/review/TranslatedReview.java
@@ -18,4 +18,7 @@ public class TranslatedReview {
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "review_id")
     private Review review;
+
+    // 편의 기능 메서드
+    public void updateBody(String newBody){this.body = newBody;}
 }

--- a/src/main/java/com/chaeshin/boo/repository/notice/BaseNoticeRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/notice/BaseNoticeRepository.java
@@ -1,0 +1,6 @@
+package com.chaeshin.boo.repository.notice;
+
+public interface BaseNoticeRepository {
+
+    void updateNotice(Long id, String newBody);
+}

--- a/src/main/java/com/chaeshin/boo/repository/notice/BaseNoticeRepositoryImpl.java
+++ b/src/main/java/com/chaeshin/boo/repository/notice/BaseNoticeRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.chaeshin.boo.repository.notice;
+
+import com.chaeshin.boo.domain.Notice;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BaseNoticeRepositoryImpl implements BaseNoticeRepository {
+
+    @PersistenceContext EntityManager em;
+
+    @Override
+    public void updateNotice(Long id, String newBody) {
+        Notice notice = em.find(Notice.class, id);
+        notice.updateNotice(newBody);
+    }
+}

--- a/src/main/java/com/chaeshin/boo/repository/notice/NoticeRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/notice/NoticeRepository.java
@@ -1,0 +1,7 @@
+package com.chaeshin.boo.repository.notice;
+
+import com.chaeshin.boo.domain.Notice;
+import org.springframework.data.repository.CrudRepository;
+
+public interface NoticeRepository extends CrudRepository<Notice, Long>, BaseNoticeRepository {
+}

--- a/src/main/java/com/chaeshin/boo/repository/restaurant/BaseRestaurantCrudRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/restaurant/BaseRestaurantCrudRepository.java
@@ -1,0 +1,18 @@
+package com.chaeshin.boo.repository.restaurant;
+
+import com.chaeshin.boo.domain.restaurant.Restaurant;
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+
+public interface BaseRestaurantCrudRepository {
+
+    /**
+     * 이름으로 식당 조회
+     *
+     * @param name
+     * @return
+     */
+    List<Restaurant> findByName(String name);
+
+
+}

--- a/src/main/java/com/chaeshin/boo/repository/restaurant/BaseRestaurantCrudRepositoryImpl.java
+++ b/src/main/java/com/chaeshin/boo/repository/restaurant/BaseRestaurantCrudRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.chaeshin.boo.repository.restaurant;
+
+import com.chaeshin.boo.domain.restaurant.Restaurant;
+import com.chaeshin.boo.repository.user.BaseUserCrudRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BaseRestaurantCrudRepositoryImpl implements BaseRestaurantCrudRepository {
+
+    @PersistenceContext EntityManager em;
+    @Override
+    public List<Restaurant> findByName(String name) {
+
+        // Case A : 공백이 name 으로 주어진 경우 - 빈 List 반환
+        if(name == null || name.trim().isEmpty()){
+            return Collections.emptyList();
+        }
+
+        // Case B : 해당 이름으로부터 공백 기준 분리한 단어 혹은 단어 전체와 name이 일치하는 Restaurant 을 List로 반환.
+        List<String> parsed = Arrays.stream(name.split(" ")).toList(); // Stream API 가 for 보다 최적화가 덜 되어 느리다는 분석을 본 적이 있다.
+        return em.createQuery("select r from Restaurant r where r.name in :names or r.name = :name", Restaurant.class)
+                .setParameter("names", parsed)
+                .setParameter("name", name)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/chaeshin/boo/repository/restaurant/MenuRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/restaurant/MenuRepository.java
@@ -1,0 +1,42 @@
+package com.chaeshin.boo.repository.restaurant;
+
+import com.chaeshin.boo.domain.restaurant.Menu;
+import com.chaeshin.boo.domain.restaurant.Restaurant;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Menu 엔티티의 경우 단독으로 Menu 를 대상으로 쿼리하는 기능 명세가 존재 하지 않는다.
+ * <br></br>
+ * Menu 를 DB 혹은 영속성 컨텍스트로부터 조회하는 시나리오는 '어떤 레스토랑의 메뉴를 전체 조회한다'만 존재하기 때문에,
+ * <br></br>
+ * Spring Data JPA 를 상속받는 인터페이스가 아닌 바로 구현체로 구현하도록 하였다.
+ * <br></br>
+ * <small>Ho Yeon Chae</small>
+ */
+@Repository
+@RequiredArgsConstructor
+public class MenuRepository {
+
+    private final EntityManager em;
+
+    /**
+     * 주어진 식당의 메뉴 전체 반환
+     * @param restaurant
+     * @return
+     */
+    List<Menu> findAllByRestaurant(Long restaurantId){
+        return em.createQuery("select m from Menu m where m.restaurant.id = :restaurantId", Menu.class)
+                .setParameter("restaurantId", restaurantId)
+                .getResultList();
+    }
+
+    /**
+     * 메뉴 저장
+     * @param menu
+     */
+    void save(Menu menu){em.persist(menu);}
+}

--- a/src/main/java/com/chaeshin/boo/repository/restaurant/RestaurantRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/restaurant/RestaurantRepository.java
@@ -1,0 +1,7 @@
+package com.chaeshin.boo.repository.restaurant;
+
+import com.chaeshin.boo.domain.restaurant.Restaurant;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RestaurantRepository extends CrudRepository<Restaurant, Long>, BaseRestaurantCrudRepository {
+}

--- a/src/main/java/com/chaeshin/boo/repository/review/BaseReviewCrudRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/review/BaseReviewCrudRepository.java
@@ -1,0 +1,24 @@
+package com.chaeshin.boo.repository.review;
+
+import com.chaeshin.boo.domain.review.Review;
+import java.util.List;
+
+public interface BaseReviewCrudRepository {
+
+    /**
+     * 회원 ID 로 리뷰 조회.
+     * <br></br>
+     * Q. ReviewRepo에서 회원 ID로 리뷰 조회 VS UserRepo에서 User Id로 검색 후 reviews 반환하기
+     * @param userId
+     * @return
+     */
+    List<Review> findAllByUserId(Long userId);
+
+    /**
+     * 식당 ID로 리뷰 조회
+     * @param restaurantId
+     * @return
+     */
+    List<Review> findAllByRestaurantId(Long restaurantId);
+
+}

--- a/src/main/java/com/chaeshin/boo/repository/review/BaseReviewCrudRepositoryImpl.java
+++ b/src/main/java/com/chaeshin/boo/repository/review/BaseReviewCrudRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.chaeshin.boo.repository.review;
+
+import com.chaeshin.boo.domain.review.Review;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BaseReviewCrudRepositoryImpl implements BaseReviewCrudRepository {
+
+    @PersistenceContext EntityManager em;
+
+    /**
+     * 회원 ID 로 리뷰 조회.
+     * <br></br>
+     * Q. 'Pageable' 도입하는 것이 좋지 않을까?
+     * @param userId
+     * @return
+     */
+    @Override
+    public List<Review> findAllByUserId(Long userId) {
+        return em.createQuery("select r from Review r where r.user.id = :userId", Review.class)
+                .setParameter("userId", userId)
+                .getResultList();
+    }
+
+    /**
+     * 식당 ID 로 리뷰 조회
+     * @param restaurantId
+     * @return
+     */
+    @Override
+    public List<Review> findAllByRestaurantId(Long restaurantId) {
+        return em.createQuery("select r from Review r where r.restaurant.id = :restaurantId", Review.class)
+                .setParameter("restaurantId", restaurantId)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/chaeshin/boo/repository/review/ReviewRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/review/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.chaeshin.boo.repository.review;
+
+import com.chaeshin.boo.domain.review.Review;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ReviewRepository extends CrudRepository<Review, Long>,  BaseReviewCrudRepository {
+}

--- a/src/main/java/com/chaeshin/boo/repository/review/reviewImage/ReviewImageRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/review/reviewImage/ReviewImageRepository.java
@@ -1,0 +1,8 @@
+package com.chaeshin.boo.repository.review.reviewImage;
+
+import com.chaeshin.boo.domain.review.ReviewImage;
+import org.springframework.data.repository.CrudRepository;
+
+public interface ReviewImageRepository extends CrudRepository<ReviewImage, Long> {
+
+}

--- a/src/main/java/com/chaeshin/boo/repository/review/translatedReview/BaseTranslatedReviewRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/review/translatedReview/BaseTranslatedReviewRepository.java
@@ -1,0 +1,13 @@
+package com.chaeshin.boo.repository.review.translatedReview;
+
+import com.chaeshin.boo.domain.review.TranslatedReview;
+import org.springframework.data.repository.CrudRepository;
+
+public interface BaseTranslatedReviewRepository {
+
+    /**
+     * 번역 수정
+     * @param newBody
+     */
+    void updateTranslatedReview(Long id, String newBody);
+}

--- a/src/main/java/com/chaeshin/boo/repository/review/translatedReview/BaseTranslatedReviewRepositoryImpl.java
+++ b/src/main/java/com/chaeshin/boo/repository/review/translatedReview/BaseTranslatedReviewRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.chaeshin.boo.repository.review.translatedReview;
+
+import com.chaeshin.boo.domain.review.TranslatedReview;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class BaseTranslatedReviewRepositoryImpl implements BaseTranslatedReviewRepository {
+
+    @PersistenceContext EntityManager em;
+
+    /**
+     * 번역 본문 수정
+     * @param newBody
+     */
+    @Override
+    public void updateTranslatedReview(Long id, String newBody) {
+        TranslatedReview found = em.find(TranslatedReview.class, id);
+        found.updateBody(newBody);
+    }
+}

--- a/src/main/java/com/chaeshin/boo/repository/review/translatedReview/TranslatedReviewRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/review/translatedReview/TranslatedReviewRepository.java
@@ -1,0 +1,7 @@
+package com.chaeshin.boo.repository.review.translatedReview;
+
+import com.chaeshin.boo.domain.review.TranslatedReview;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TranslatedReviewRepository extends CrudRepository<TranslatedReview, Long>, BaseTranslatedReviewRepository {
+}

--- a/src/main/java/com/chaeshin/boo/repository/user/BaseUserCrudRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/user/BaseUserCrudRepository.java
@@ -1,0 +1,27 @@
+package com.chaeshin.boo.repository.user;
+
+import com.chaeshin.boo.domain.User;
+import java.util.List;
+
+public interface BaseUserCrudRepository {
+
+    /**
+     * 회원 닉네임으로 검색
+     * @param nickname
+     */
+    List<User> findByNickname(String nickname);
+
+    /**
+     * 회원 구글 id로 검색
+     * @param email
+     */
+    List<User> findByGoogleId(String googleId);
+
+    /**
+     * ID로 회원 조회 후 param으로 주어진 nickname으로 변경
+     * @param id
+     * @param nickname
+     */
+    void updateNickname(Long id, String nickname);
+
+}

--- a/src/main/java/com/chaeshin/boo/repository/user/BaseUserCrudRepositoryImpl.java
+++ b/src/main/java/com/chaeshin/boo/repository/user/BaseUserCrudRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.chaeshin.boo.repository.user;
+
+import com.chaeshin.boo.domain.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * BaseUserCrudRepository 구현체.
+ */
+
+@Repository // 사용자 정의 Repository interface 의 구현체 이름 뒤에 'Impl' + @Repository -> Spring Data JPA 가 자동 인식.
+public class BaseUserCrudRepositoryImpl implements BaseUserCrudRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    /**
+     * 회원 닉네임으로 조회.
+     * @param nickname
+     * @return List of User
+     */
+    @Override
+    public List<User> findByNickname(String nickname) {
+        return em.createQuery("select u from User u where u.nickname = :nickname", User.class)
+                .setParameter("nickname", nickname)
+                .getResultList();
+    }
+
+    /**
+     * 회원 Google ID 로 조회
+     * @param googleId
+     * @return List of User
+     */
+    @Override
+    public List<User> findByGoogleId(String googleId) {
+        return em.createQuery("select u from User u where u.googleId = :googleId", User.class)
+                .setParameter("googleId", googleId)
+                .getResultList();
+    }
+
+    @Override
+    public void updateNickname(Long id, String nickname) {
+        User user = em.find(User.class, id); // Q. 예외 처리를 어떻게 할 것인가?
+        user.updateUserNickname(nickname); // Dirty Check 와 Domain 편의 기능을 함께 활용한 변경 Query method.
+    }
+}

--- a/src/main/java/com/chaeshin/boo/repository/user/UserRepository.java
+++ b/src/main/java/com/chaeshin/boo/repository/user/UserRepository.java
@@ -1,0 +1,9 @@
+package com.chaeshin.boo.repository.user;
+
+
+import com.chaeshin.boo.domain.User;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+public interface UserRepository extends CrudRepository<User, Long>, BaseUserCrudRepository {
+}

--- a/src/test/java/com/chaeshin/boo/repository/notice/NoticeRepositoryTest.java
+++ b/src/test/java/com/chaeshin/boo/repository/notice/NoticeRepositoryTest.java
@@ -1,0 +1,80 @@
+package com.chaeshin.boo.repository.notice;
+
+import com.chaeshin.boo.domain.Notice;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class NoticeRepositoryTest {
+
+    @Autowired
+    NoticeRepository noticeRepository;
+
+    @Test
+    void 공지_생성(){
+        // given
+        Notice notice = new Notice();
+        ReflectionTestUtils.setField(notice, "id", 1L);
+
+        // when
+        Notice created = noticeRepository.save(notice);
+
+        // then
+        Assertions.assertNotNull(created);
+    }
+
+    @Test
+    void 공지_조회(){
+        //given
+        Notice notice = new Notice();
+        ReflectionTestUtils.setField(notice, "id", 1L);
+
+        //when
+        Notice created = noticeRepository.save(notice);
+        Optional<Notice> found = noticeRepository.findById(created.getId());
+
+        // then
+        Assertions.assertTrue(found.isPresent());
+        Assertions.assertEquals(found.get().getId(), created.getId());
+    }
+
+    @Test
+    void 공지_수정(){
+
+        // given
+        Notice notice = new Notice();
+        ReflectionTestUtils.setField(notice, "id", 1L);
+        noticeRepository.save(notice);
+
+        // when
+        noticeRepository.updateNotice(notice.getId(), "updated!");
+        Optional<Notice> found = noticeRepository.findById(notice.getId());
+
+        // then
+        Assertions.assertTrue(found.isPresent());
+        Assertions.assertEquals(found.get().getBody(), "updated!");
+
+    }
+
+    @Test
+    void 공지_삭제(){
+        //given
+        Notice notice = new Notice();
+        ReflectionTestUtils.setField(notice, "id", 1L);
+
+        // when
+        Notice created = noticeRepository.save(notice);
+        noticeRepository.delete(notice);
+        Optional<Notice> found = noticeRepository.findById(created.getId());
+
+        // then
+        Assertions.assertFalse(found.isPresent());
+
+    }
+}

--- a/src/test/java/com/chaeshin/boo/repository/restaurant/MenuRepositoryTest.java
+++ b/src/test/java/com/chaeshin/boo/repository/restaurant/MenuRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.chaeshin.boo.repository.restaurant;
+
+import com.chaeshin.boo.domain.restaurant.Menu;
+import com.chaeshin.boo.domain.restaurant.Restaurant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class MenuRepositoryTest {
+
+    @Autowired MenuRepository menuRepository;
+    @Autowired RestaurantRepository restaurantRepository;
+
+    @Test
+    void 식당으로_메뉴_조회(){
+
+        // Scenario
+        // 식당 : {name : "레알라면, id : 1L, Menu : "라면"}
+        // 메뉴 : {name : "라면", Restaurant_id : 1L}
+
+        // given
+        Restaurant restaurant = new Restaurant();
+        ReflectionTestUtils.setField(restaurant, "name", "레알라면");
+        ReflectionTestUtils.setField(restaurant, "id", 1L);
+        restaurantRepository.save(restaurant);
+
+        // when
+        Menu menu = new Menu();
+        ReflectionTestUtils.setField(menu, "restaurant", restaurant);
+        ReflectionTestUtils.setField(menu, "name", "라면");
+
+        menuRepository.save(menu);
+
+        // then
+        List<Menu> found = menuRepository.findAllByRestaurant(restaurant.getId());
+
+        Assertions.assertFalse(found.isEmpty());
+        Assertions.assertEquals(found.get(0).getName(), "라면");
+
+    }
+}

--- a/src/test/java/com/chaeshin/boo/repository/restaurant/RestaurantRepositoryTest.java
+++ b/src/test/java/com/chaeshin/boo/repository/restaurant/RestaurantRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.chaeshin.boo.repository.restaurant;
+
+import com.chaeshin.boo.domain.restaurant.Restaurant;
+import java.util.List;
+import java.util.Optional;
+import org.aspectj.util.Reflection;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class RestaurantRepositoryTest {
+
+    @Autowired RestaurantRepository restaurantRepository;
+
+    @Test
+    void 식당_저장(){
+        // given
+        Restaurant res = new Restaurant();
+        ReflectionTestUtils.setField(res, "name", "레알라면");
+
+        // when
+        Restaurant found = restaurantRepository.save(res);
+
+        // then
+        Assertions.assertNotNull(found);
+        Assertions.assertEquals(found.getName(), "레알라면");
+    }
+
+    @Test
+    void 식당_Id_조회(){
+        // given
+        Restaurant res = new Restaurant();
+        ReflectionTestUtils.setField(res, "id", 1L);
+
+        // when
+        Restaurant found = restaurantRepository.save(res);
+
+        // then
+        Assertions.assertNotNull(found);
+        Assertions.assertEquals(found.getId(), 1L);
+    }
+
+    // @Test
+    // void 식당_저장_이름으로_조회(){
+    //     // given
+    //     Restaurant restaurant = new Restaurant();
+    //     ReflectionTestUtils.setField(restaurant, "name", "할머니보쌈");
+    //
+    //     // when
+    //     restaurantRepository.save(restaurant);
+    //     List<Restaurant> found = restaurantRepository.findByName("할머니 보쌈");
+    //
+    //     Assertions.assertFalse(found.isEmpty()); // 빈 리스트가 아닌지 체크 -> 실패!
+    //
+    //
+    // }
+}

--- a/src/test/java/com/chaeshin/boo/repository/review/ReviewImageRepositoryTest.java
+++ b/src/test/java/com/chaeshin/boo/repository/review/ReviewImageRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.chaeshin.boo.repository.review;
+
+import com.chaeshin.boo.domain.review.Review;
+import com.chaeshin.boo.domain.review.ReviewImage;
+import com.chaeshin.boo.repository.review.reviewImage.ReviewImageRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 현재 테스트 메서드 단위로 실행 시 통과. 하지만 클래스 단위로 실행시 실패. 뭐가 문제일까?
+ */
+@SpringBootTest
+@Transactional
+public class ReviewImageRepositoryTest {
+
+    @Autowired ReviewImageRepository reviewImageRepository;
+    @Autowired ReviewRepository reviewRepository;
+
+    @Test
+    void 리뷰_이미지_생성(){
+        // given
+        ReviewImage reviewImage = new ReviewImage();
+        Review review = new Review();
+        ReflectionTestUtils.setField(review, "id", 1L);
+        reviewRepository.save(review);
+
+        ReflectionTestUtils.setField(reviewImage, "imageUrl", "/any/photo");
+        ReflectionTestUtils.setField(reviewImage, "review", review);
+
+        // when
+        ReviewImage created = reviewImageRepository.save(reviewImage);
+
+        // then
+        Assertions.assertNotNull(created);
+        Assertions.assertEquals(created.getImageUrl(), reviewImage.getImageUrl());
+    }
+
+    @Test
+    void 리뷰_이미지_조회(){
+        // given
+        ReviewImage reviewImage = new ReviewImage();
+        Review review = new Review();
+        ReflectionTestUtils.setField(review, "id", 1L);
+        reviewRepository.save(review);
+
+        ReflectionTestUtils.setField(reviewImage, "imageUrl", "/any/photo");
+        ReflectionTestUtils.setField(reviewImage, "review", review);
+        ReviewImage created = reviewImageRepository.save(reviewImage);
+
+        // when
+        Optional<ReviewImage> found = reviewImageRepository.findById(created.getId());
+
+        // then
+        Assertions.assertTrue(found.isPresent());
+        Assertions.assertEquals(found.get().getId(), created.getId());
+
+    }
+
+    @Test
+    void 리뷰_이미지_수정(){
+        // given
+        ReviewImage reviewImage = new ReviewImage();
+        Review review = new Review();
+        ReflectionTestUtils.setField(review, "id", 1L);
+        reviewRepository.save(review);
+
+        ReflectionTestUtils.setField(reviewImage, "imageUrl", "/any/photo");
+        ReflectionTestUtils.setField(reviewImage, "review", review);
+
+        ReviewImage created = reviewImageRepository.save(reviewImage);
+
+        // when
+        created.updateReviewImage("/any/changed");
+        Optional<ReviewImage> found = reviewImageRepository.findById(created.getId());
+
+        // then
+        Assertions.assertTrue(found.isPresent());
+        Assertions.assertEquals(found.get().getImageUrl(), created.getImageUrl());
+    }
+
+    @Test
+    void 리뷰_이미지_삭제(){
+        // given
+        ReviewImage reviewImage = new ReviewImage();
+        Review review = new Review();
+        ReflectionTestUtils.setField(review, "id", 1L);
+        reviewRepository.save(review);
+
+        ReflectionTestUtils.setField(reviewImage, "imageUrl", "/any/photo");
+        ReflectionTestUtils.setField(reviewImage, "review", review);
+
+        reviewImageRepository.save(reviewImage);
+
+        // when
+        reviewImageRepository.delete(reviewImage);
+        Optional<ReviewImage> found = reviewImageRepository.findById(reviewImage.getId());
+
+        // then
+        Assertions.assertFalse(found.isPresent());
+
+    }
+
+}

--- a/src/test/java/com/chaeshin/boo/repository/review/ReviewRepositoryTest.java
+++ b/src/test/java/com/chaeshin/boo/repository/review/ReviewRepositoryTest.java
@@ -1,0 +1,120 @@
+package com.chaeshin.boo.repository.review;
+
+import com.chaeshin.boo.domain.User;
+import com.chaeshin.boo.domain.restaurant.Restaurant;
+import com.chaeshin.boo.domain.review.Review;
+import com.chaeshin.boo.repository.restaurant.RestaurantRepository;
+import com.chaeshin.boo.repository.user.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class ReviewRepositoryTest {
+
+    @Autowired ReviewRepository reviewRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired RestaurantRepository restaurantRepository;
+
+    @Test
+    void 리뷰_저장(){
+        // given
+        Review review = new Review();
+        ReflectionTestUtils.setField(review, "id", 1L);
+
+        // when
+        Review found = reviewRepository.save(review);
+
+        // then
+        Assertions.assertNotNull(found);
+        Assertions.assertEquals(found.getId(), review.getId());
+    }
+
+    @Test
+    void 리뷰_ID_조회(){
+
+        // given
+        Review review = new Review();
+        ReflectionTestUtils.setField(review, "id", 1L);
+        reviewRepository.save(review);
+
+        // when
+        Optional<Review> found = reviewRepository.findById(review.getId());
+
+        // then
+        Assertions.assertTrue(found.isPresent());
+        Assertions.assertEquals(found.get().getId(), review.getId());
+    }
+
+    @Test
+    void 회원_ID_리뷰_조회(){
+        // given
+        User user = new User();
+        ReflectionTestUtils.setField(user, "nickname", "testUser");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        userRepository.save(user);
+
+        // when
+        Review review = new Review();
+        ReflectionTestUtils.setField(review, "user", user);
+        reviewRepository.save(review);
+
+        List<Review> found = reviewRepository.findAllByUserId(user.getId());
+
+        // then
+        Assertions.assertFalse(found.isEmpty());
+        Assertions.assertEquals(found.get(0).getUser().getId(), user.getId());
+
+    }
+
+    @Test
+    void 식당_ID_리뷰_조회(){
+        // given
+        Restaurant res = new Restaurant();
+        ReflectionTestUtils.setField(res, "name", "testRes");
+        ReflectionTestUtils.setField(res, "id", 1L);
+        restaurantRepository.save(res);
+
+        // when
+        Review review = new Review();
+        ReflectionTestUtils.setField(review, "restaurant", res);
+        reviewRepository.save(review);
+
+        List<Review> found = reviewRepository.findAllByRestaurantId(res.getId());
+
+        // then
+        Assertions.assertFalse(found.isEmpty());
+        Assertions.assertEquals(found.get(0).getRestaurant().getId(), res.getId());
+    }
+
+
+    /**
+     * Review 수정의 경우 Entity에 편의 기능 - 제목 변경 / 본문 변경 - 을 만들어 두었다.
+     * <p></p>
+     * 이를 활용하여 Service Layer 에서 제공하는 것이 적절하지 않을까? 하는 생각이 든다!
+     */
+    @Test
+    void 리뷰_수정(){
+    }
+
+    @Test
+    void 리뷰_삭제(){
+        // given
+        Review review = new Review();
+        ReflectionTestUtils.setField(review, "id", 1L);
+        reviewRepository.save(review);
+
+        // when
+        reviewRepository.delete(review);
+        Optional<Review> found = reviewRepository.findById(review.getId());
+
+        // then
+        Assertions.assertFalse(found.isPresent());
+    }
+}

--- a/src/test/java/com/chaeshin/boo/repository/review/TranslatedReviewTest.java
+++ b/src/test/java/com/chaeshin/boo/repository/review/TranslatedReviewTest.java
@@ -1,0 +1,93 @@
+package com.chaeshin.boo.repository.review;
+
+import com.chaeshin.boo.domain.review.TranslatedReview;
+import com.chaeshin.boo.repository.review.translatedReview.BaseTranslatedReviewRepository;
+import com.chaeshin.boo.repository.review.translatedReview.TranslatedReviewRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class TranslatedReviewTest {
+
+    @Autowired
+    TranslatedReviewRepository translatedReviewRepository;
+    @Autowired ReviewRepository reviewRepository;
+
+    /**
+     * @NotNull 제약 추가시 테스트 수정해야함.
+     */
+    @Test
+    void 리뷰_번역_생성(){
+        // given
+        TranslatedReview transR = new TranslatedReview();
+        ReflectionTestUtils.setField(transR, "body", "Translated");
+
+        // when
+        TranslatedReview created = translatedReviewRepository.save(transR);
+
+        // then
+        Assertions.assertNotNull(created);
+        Assertions.assertEquals(created.getBody(), transR.getBody());
+    }
+
+    @Test
+    void 리뷰_번역_조회(){
+        // given
+        TranslatedReview transR = new TranslatedReview();
+        ReflectionTestUtils.setField(transR, "body", "Translated");
+        ReflectionTestUtils.setField(transR, "id", 1L);
+
+        // when
+        translatedReviewRepository.save(transR);
+        Optional<TranslatedReview> found = translatedReviewRepository.findById(transR.getId());
+
+        // then
+        Assertions.assertTrue(found.isPresent());
+        Assertions.assertEquals(found.get().getId(), transR.getId());
+    }
+
+    @Test
+    void 리뷰_번역_수정(){
+        // given
+        TranslatedReview transR = new TranslatedReview();
+        ReflectionTestUtils.setField(transR, "body", "Translated");
+        ReflectionTestUtils.setField(transR, "id", 1L);
+
+        // when
+        translatedReviewRepository.save(transR);
+        translatedReviewRepository.updateTranslatedReview(1L, "changed!");
+
+        Optional<TranslatedReview> found = translatedReviewRepository.findById(1L);
+
+        // then
+        Assertions.assertTrue(found.isPresent());
+        Assertions.assertEquals(found.get().getBody(), "changed!");
+
+
+    }
+
+    @Test
+    void 리뷰_번역_삭제(){
+        // given
+        TranslatedReview transR = new TranslatedReview();
+        ReflectionTestUtils.setField(transR, "body", "Translated");
+        ReflectionTestUtils.setField(transR, "id", 1L);
+
+        TranslatedReview created = translatedReviewRepository.save(transR);
+
+        // when
+        translatedReviewRepository.delete(created);
+        Optional<TranslatedReview> found = translatedReviewRepository.findById(created.getId());
+
+        // then
+        Assertions.assertFalse(found.isPresent());
+    }
+
+
+}

--- a/src/test/java/com/chaeshin/boo/repository/user/UserRepositoryTest.java
+++ b/src/test/java/com/chaeshin/boo/repository/user/UserRepositoryTest.java
@@ -1,0 +1,104 @@
+package com.chaeshin.boo.repository.user;
+
+import com.chaeshin.boo.domain.User;
+import com.chaeshin.boo.domain.review.Review;
+import com.chaeshin.boo.repository.user.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+// import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+// import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+// import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+// Q. 아래의 Annotation 조합으로도 테스트가 가능함. 어떤 차이일까...?
+// @DataJpaTest
+// @AutoConfigureTestDatabase(replace = Replace.NONE)
+@SpringBootTest
+@Transactional
+public class UserRepositoryTest {
+    @Autowired UserRepository userRepository;
+
+    @Test
+    void 회원_가입_ID_조회(){
+        User user = new User();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "nickname", "test");
+        userRepository.save(user);
+
+        Optional<User> found = userRepository.findById(1L); // Optional<T> : 해당 객체가 null 일지 아닐지 확실하지 않은 경우에 안전하게 객체를 확인하고 처리하기 위한 일종의 Wrapper Class.
+
+        Assertions.assertTrue(found.isPresent()); // True : 영속성 컨텍스트에 해당 Entity 가 존재함.
+        Assertions.assertEquals(user.getNickname(), found.get().getNickname());
+    }
+
+    @Test
+    void 닉네임_회원_조회(){
+        User user = new User();
+        ReflectionTestUtils.setField(user, "nickname", "test");
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        userRepository.save(user);
+
+        List<User> found = userRepository.findByNickname("test");
+
+        for(User usr : found){
+            System.out.println("usr.nickname = " + usr.getNickname());
+        }
+
+        Assertions.assertFalse(found.isEmpty());
+    }
+
+    @Test
+    void 구글_ID_회원_조회(){
+        User user = new User();
+        ReflectionTestUtils.setField(user, "googleId", "blah@google.com");
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        userRepository.save(user);
+
+        List<User> found = userRepository.findByGoogleId("blah@google.com");
+
+        for(User usr : found){
+            System.out.println("usr.googleId = " + usr.getGoogleId());
+        }
+
+        Assertions.assertFalse(found.isEmpty());
+    }
+
+    @Test
+    void 회원_닉네임_변경(){
+        User user = new User();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "nickname", "before");
+
+        userRepository.save(user);
+
+        userRepository.updateNickname(user.getId(), "after");
+
+        Optional<User> found = userRepository.findById(user.getId());
+
+        Assertions.assertTrue(found.isPresent());
+        Assertions.assertEquals(found.get().getNickname(), "after");
+    }
+
+    @Test
+    void 회원_삭제(){
+        // given
+        User user = new User();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        userRepository.save(user);
+
+        // when
+        userRepository.delete(user);
+        Optional<User> found = userRepository.findById(user.getId());
+
+        // then
+        Assertions.assertFalse(found.isPresent());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/boo
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
## 1. 중점 사항
 - Repository 설계 시 Spring Data JPA 에서 제공하는 Repository interface 와 각 도메인 별 별도 query method 를 함께 제공 및 정의 하기 위해 다음과 같은 구조로 설계 하였습니다.
 > `Base[DomainName]Repository` : 해당 도메인 에만 사용되는 query method 명세
 > `Base[DomainName]RepositoryImpl` : 상기한 인터페이스의 구현체. Spring Data JPA는 `Impl` 접미어를 자동으로 인식하여 해당 클래스가 어떤 인터페이스의 구현체인지 자동으로 인식합니다.
> `[DomainName]Repository` extends `CrudRepository<Entity, Long>`, `Base[DomainName]Repository` : 해당  도메인의 메인 Repository.

- 다 대 일 관계를 맺고있는 두 엔티티의 Repository 를 설계할 때, '일'에서 '다'를 조회하도록 설계 하였습니다. (Review-User 제외.) 
> 예를 들어 '어떤 Review의 ReviewImage를 모두 조회한다' 라는 기능 명세가 있을 때, ReviewImageRepository 에 `findAllByReviewId()`를 정의하는 것이 아닌 Service layer에서 review id 로 ReviewRepository로부터 Review를 조회한 후 해당 Review의 읽기 전용 필드인 `reviewImages`를 반환하도록 설계한 것입니다.
> 어느 것이 좋은 지에 대해서는 함께 논의 및 조사가 필요할 것 같습니다 :)!

- Review, Notice, ReviewImage, TranslatedRevie 엔티티에 변경을 위한 편의 메서드를 넣었습니다!
> 각 엔티티의 body 필드 혹은 imageUrl 필드에 대한 변경을 제공하는 기능 명세가 존재하기 때문에 이를 고려하여 추가 작성하였습니다.
> Repository 의 쿼리 메서드 내에서 수행할 수 있음에도 Domain 설계 내에 수정 로직을 추가한 이유는, Setter를 제외한 Entity 설계 원칙을 지키기 위해서 입니다! Hibernate가 제공하는 Dirty-checking 덕분에(?) 해당 로직이 Repository 의 쿼리 메서드이기보단 Entity의 내용 변경에 좀 더 가깝다고 생각해서이기도 합니다!

 - 검색 로직은 조금 더 보완이 필요할 것 같아 완성하지 않고 우선 올립니다..! JPQL 내에서 해결해보려 하였으나 이도저도 아니게 된 관계로... 조금 더 알아보고 구현해보고픈 방향은 MySQL이 지원 하는 전문 검색(Full Text Search) 입니다.
 
 close #6 